### PR TITLE
Install required Bower dependencies on npm postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,17 +11,21 @@
     "LICENSE",
     "Readme.md",
     "index.js",
-    "lib/"
+    "lib/",
+    "bower.json",
+    ".bowerrc"
   ],
   "scripts": {
     "start": "gulp simple",
     "test": "gulp test",
-    "test-ci": "istanbul cover -x 'examples' _mocha -- tests/ -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
+    "test-ci": "istanbul cover -x 'examples' _mocha -- tests/ -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
+    "postinstall": "bower install"
   },
   "author": "",
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.14.1",
+    "bower": "^1.7.7",
     "express": ">=4.0",
     "express-session": "^1.12.1",
     "jade": "^1.11.0",


### PR DESCRIPTION
Fixes #27

I don't really know my way around npm so I'm not sure if this is the best approach and/or all that is required, but I just tested it locally and seems to be working.
